### PR TITLE
Buttonstyles

### DIFF
--- a/react/button/Button.stories.tsx
+++ b/react/button/Button.stories.tsx
@@ -4,12 +4,116 @@ const metadata = { title: 'Button' };
 export default metadata;
 
 export const Example = () => (
-  <div className="flex flex-col space-y-32">
+  <div className="flex flex-col space-32">
+    <div>
+      <h3>Variants</h3>
+      <p>Allowed values: empty, or one of variant</p>
+      <Button>
+        Default
+      </Button>
+
+      <Button primary>
+        Primary
+      </Button>
+
+      <Button secondary>
+        Secondary
+      </Button>
+
+      <Button negative>
+        Negative
+      </Button>
+
+      <Button utility>
+        Utility
+      </Button>
+
+      <Button quiet>
+        Quiet
+      </Button>
+
+      <Button negativeQuiet>
+        Negative-Quiet
+      </Button>
+
+      <Button utilityQuiet>
+        utility-Quiet
+      </Button>
+
+      <p>This is a <Button link>button</Button> pretending to be a link.</p>
+    </div>
+
+    <div>
+      <h3>Sizes</h3>
+      <p>Allowed values: empty(default) or one size </p>
+      <Button>
+        Default
+      </Button>
+
+      <Button small>
+        Default small
+      </Button>
+    </div>
+
+    <div>
+      <h3>widths</h3>
+      <p>Allowed values: empty(default) or one width </p>
+      <Button>
+        Default
+      </Button>
+
+      <Button fullWidth>
+        Default fullWidth
+      </Button>
+    </div>
+
+    <div>
+      <h3>States</h3>
+      <p>Allowed values: empty(default) or any number of states</p>
+      <p>Loading state, Pattern is supposed to be: button is triggered, button is disabled until loading success, while in the disabled state it also show loading animation to show something is happening.</p>
+      <Button>
+        Default
+      </Button>
+
+      <Button disabled>
+        Default disabled
+      </Button>
+
+      <Button loading>
+        Default loading
+      </Button>
+    </div>
+
+
+<h2>All combos</h2>
+    <div>
+      <h3>Default (Secondary)</h3>
+      <Button className="mr-32" >
+        Button
+      </Button>
+
+      <Button className="mr-32" loading disabled>
+        Loading
+      </Button>
+
+      <Button className="mr-32" small>
+        Small
+      </Button>
+
+      <Button className="mr-32" small loading>
+        Small Loading
+      </Button>
+
+      <Button disabled className="mr-32" >
+        Disabled
+      </Button>
+
+    </div>
     <div>
       <h3>Primary</h3>
 
       <Button className="mr-32" primary>
-        Simple
+        Button
       </Button>
 
       <Button className="mr-32" primary loading>
@@ -23,36 +127,16 @@ export const Example = () => (
       <Button className="mr-32" primary small loading>
         Small Loading
       </Button>
-
-      <Button className="mr-32" primary quiet>
-        Quiet
-      </Button>
-
-      <Button className="mr-32" primary quiet small>
-        Quiet Small
-      </Button>
-
-      <Button className="mr-32" primary quiet small loading>
-        Quiet Small Loading
-      </Button>
     </div>
     <div>
       <h3>Secondary</h3>
 
       <Button className="mr-32" secondary>
-        Simple
+        Button
       </Button>
 
       <Button className="mr-32" secondary loading>
         Loading
-      </Button>
-
-      <Button className="mr-32" secondary quiet>
-        Quiet
-      </Button>
-
-      <Button className="mr-32" secondary quiet loading>
-        Quiet Loading
       </Button>
 
       <Button className="mr-32" secondary small>
@@ -63,19 +147,12 @@ export const Example = () => (
         Small Loading
       </Button>
 
-      <Button className="mr-32" secondary quiet small>
-        Quiet Small
-      </Button>
-
-      <Button className="mr-32" secondary quiet small loading>
-        Quiet Small Loading
-      </Button>
     </div>
     <div>
       <h3>Negative</h3>
 
       <Button className="mr-32" negative>
-        Negative
+        Button
       </Button>
 
       <Button className="mr-32" negative loading>
@@ -89,28 +166,12 @@ export const Example = () => (
       <Button className="mr-32" negative small loading>
         Negative Small Loading
       </Button>
-
-      <Button className="mr-32" negative quiet>
-        Quiet
-      </Button>
-
-      <Button className="mr-32" negative quiet loading>
-        Quiet Loading
-      </Button>
-
-      <Button className="mr-32" negative quiet small>
-        Quiet Small
-      </Button>
-
-      <Button className="mr-32" negative quiet small loading>
-        Quiet Small Loading
-      </Button>
     </div>
     <div>
       <h3>Utility</h3>
 
       <Button className="mr-32" utility>
-        Simple
+        Button
       </Button>
 
       <Button className="mr-32" utility loading>
@@ -124,29 +185,11 @@ export const Example = () => (
       <Button className="mr-32" utility small loading>
         Small Loading
       </Button>
-
-      <Button className="mr-32" utility quiet>
-        Quiet
-      </Button>
-
-      <Button className="mr-32" utility quiet small>
-        Quiet small
-      </Button>
     </div>
+
     <div>
-      <h3>Pill</h3>
-
-      <Button className="mr-32" pill>
-        Simple pill
-      </Button>
-
-      <Button className="mr-32" pill small>
-        Simple small pill
-      </Button>
-
-      <Button className="mr-32" pill loading>
-        Loading
-      </Button>
+      <h3>Link</h3>
+      This is a <Button className="mr-32" link>button</Button> pretending to be a link.
     </div>
 
     <div>
@@ -155,6 +198,14 @@ export const Example = () => (
       <Button fullWidth className="mr-32" primary>
         Full width
       </Button>
+    </div>
+
+    <div>
+      <h3>Everything</h3>
+      <p>primary secondary negative utility quiet link small loading fullwidth disabled</p>
+
+      <Button primary secondary negative utility quiet link small loading fullwidth disabled>All things</Button>
+
     </div>
   </div>
 );

--- a/react/button/Button.stories.tsx
+++ b/react/button/Button.stories.tsx
@@ -85,7 +85,7 @@ export const Example = () => (
     </div>
 
 
-<h2>All combos</h2>
+    <h2 style={{ marginTop: '100px' }}>All combos</h2>
     <div>
       <h3>Default (Secondary)</h3>
       <Button className="mr-32" >

--- a/react/button/Button.tsx
+++ b/react/button/Button.tsx
@@ -14,12 +14,12 @@ import { messages as svMessages } from './locales/sv/messages.mjs';
 activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
 
 export const Button = (props: ButtonProps, ref?: RefObject<any>) => {
-  const { primary, secondary, negative, utility, quiet, small, pill, loading, fullWidth, disabled, className } = props;
+  const { primary, secondary, negative, utility, quiet, negativeQuiet, utilityQuiet, link, small, loading, fullWidth, disabled, className } = props;
 
   // Get the classes from the props.
   const classes = classNames(
     'w-button',
-    toClass({ primary, secondary, negative, utility, quiet, small, pill, loading, fullWidth }),
+    toClass({ primary, secondary, negative, utility, quiet, negativeQuiet, utilityQuiet, link, small, loading, fullWidth }),
     className,
   );
 
@@ -47,6 +47,23 @@ export const Button = (props: ButtonProps, ref?: RefObject<any>) => {
 };
 
 // Convert the fields to class names with a prefix.
+/*
+Can we maybe just map theses out ?
+
+  primary: 'w-button--primary',
+  secondary: 'w-button--secondary',
+  negative: 'w-button--negative',
+  utility: 'w-button--utility',
+  link: 'w-button--link',
+  quiet: 'w-button--quiet',
+  negativeQuiet: 'w-button--negative-quiet',
+  utilityQuiet: 'w-button--utility-quiet',
+  small: 'w-button--small',
+  pill: 'w-button--pill',
+  fullWidth: 'w-button--full-width',
+  loading: 'w-button--loading',
+
+*/
 export function toClass(object: Record<string, any>) {
   const prefix = 'w-button--';
 

--- a/react/button/props.ts
+++ b/react/button/props.ts
@@ -47,10 +47,28 @@ export type ButtonProps = {
   utility?: boolean;
 
   /**
-   * Quieten down the button, can be combined with other button types
+   * Set the button to look like a link
+   * @default false
+   */
+  link?: boolean;
+
+  /**
+   * Quieten down the button
    * @default false
    */
   quiet?: boolean;
+
+  /**
+   * Quieten down the button, negative style
+   * @default false
+   */
+  negativeQuiet?: boolean;
+
+  /**
+   * Quieten down the button, utility style
+   * @default false
+   */
+  utilityQuiet?: boolean;
 
   /**
    * Set the button to be a small size, can be combined with other button types

--- a/react/button/style.css
+++ b/react/button/style.css
@@ -1,30 +1,153 @@
-.w-button {
-  /* default variant? */
+.w-button, .w-button--secondary {
+  /* Local scoped variables, given the default button (the secondary variant) as a default */
+  --_background: var(--background, var(--w-s-color-background));
+  --_background-hover: var(--background-hover, var(--w-s-color-background-hover));
+  --_background-active: var(--background-active, var(--w-s-color-background-active));
+  --_text-color: var(--color, var(--w-s-color-text-link));
+  --_border-width: var(--border-width, 2px);
+  --_border: var(--border, var(--w-s-color-border));
+  --_border-hover: var(--border-hover, var(--w-s-color-border-hover));
+  --_border-active: var(--border-active, var(--w-s-color-border-active));
+  --_border-radius: var(--border-radius, 8px);
+  --_font-size: var(--font-size, var(--w-font-size-m));
+  --_line-height: var(--line-height, var(--w-line-height-m));
+  --_font-weight: var(--font-weight, bold);
+  --_padding-x: var(--padding-x, 16px);
+  --_padding-y: var(--padding-y, 13px);
+
+  /* Base setup for all buttons */
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  cursor: pointer;
+  transition: color 150ms cubic-bezier(0.4, 0, 0.2, 1),
+              background-color 150ms cubic-bezier(0.4, 0, 0.2, 1),
+              border-color 150ms cubic-bezier(0.4, 0, 0.2, 1),
+              fill 150ms cubic-bezier(0.4, 0, 0.2, 1),
+              stroke 150ms cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* Hook the local vars up to the button stuff  */
+  background-color: var(--_background);
+  color: var(--_text-color);
+  border: var(--_border-width) solid var(--_border);
+  border-radius: var(--_border-radius);
+  padding: calc(var(--_padding-y) - var(--_border-width)) calc(var(--_padding-x) - var(--_border-width));
+  font-size: var(--_font-size);
+  line-height: var(--_line-height);
+  font-weight: var(--_font-weight);
 }
 
+.w-button:hover {
+  background-color: var(--_background-hover);
+  border-color: var(--_border-hover);
+}
+
+.w-button:active {
+  background-color: var(--_background-active);
+  border-color: var(--_border-active);
+}
+
+
+/* Variants config */
 .w-button--primary {
+  --background: var(--w-s-color-background-primary);
+  --background-hover: var(--w-s-color-background-primary-hover);
+  --background-active: var(--w-s-color-background-primary-active);
+  --color: var(--w-s-color-text-inverted);
+  --border-width: 0px;
 }
-
-.w-button--secondary {
-}
-
 .w-button--negative {
+  --background: var(--w-s-color-background-negative);
+  --background-hover: var(--w-s-color-background-negative-hover);
+  --background-active: var(--w-s-color-background-negative-active);
+  --color: var(--w-s-color-text-inverted);
+  --border-width: 0px;
 }
-
 .w-button--utility {
+  --background: var(--w-s-color-background);
+  --background-hover: var(--w-s-color-background-hover);
+  --background-active: var(--w-s-color-background-active);
+  --color: var(--w-s-color-text);
+  --border-radius: 4px;
+  --border-width: 1px;
 }
 
 .w-button--quiet {
+  --border-width: 0px;
+}
+.w-button--negative-quiet, .w-button--negativequiet {
+  --background: transparent;
+  --background-hover: var(--w-s-color-background-negative-subtle-hover);
+  --background-active: var(--w-s-color-background-negative-subtle-active);
+  --color: var(--w-s-color-text-negative);
+  --border-width: 0px;
 }
 
-.w-button--small {
+.w-button--utility-quiet, .w-button--utilityquiet {
+  --background: transparent;
+  --color: var(--w-s-color-text);
+  --border-width: 0px;
 }
 
-.w-button--pill {
+.w-button--link{
+  --background: none;
+  --background-hover: none;
+  --background-active: none;
+  --border-width: 0;
+  --font-weight: normal;
+  display: inline;
 }
 
+/* States config,  selects --loading as well since loading is always supposed to be disabled */
+.w-button:disabled,
+.w-button--disabled,
 .w-button--loading {
+  --background: var(--w-s-color-background-disabled);
+  --background-hover: var(--w-s-color-background-disabled);
+  --background-active: var(--w-s-color-background-disabled);
+  --color: var(--w-s-color-text-inverted);
+  --border-width: 0px;
+  pointer-events: none;
 }
 
-.w-button--fullwidth {
+.w-button--link:hover {
+  text-decoration: underline;
+}
+
+/* Sizes config */
+.w-button--small {
+  --padding-x: 12px;
+  --padding-y: 8px;
+  --font-size: var(--w-font-size-xs);
+  --line-height: var(--w-line-height-xs);
+}
+
+/* Width config */
+.w-button--full-width, .w-button--fullwidth{
+  width: 100%;
+  max-width: 100%;
+}
+
+/* Copy of loading animation from warp  */
+.w-button--loading {
+  background-image: linear-gradient(135deg,
+      rgba(0, 0, 0, 0.05) 25%,
+      transparent 25%,
+      transparent 50%,
+      rgba(0, 0, 0, 0.05) 50%,
+      rgba(0, 0, 0, 0.05) 75%,
+      transparent 75%,
+      transparent);
+  background-size: 30px 30px;
+  animation: animate-inprogress 3s linear infinite;
+}
+
+@keyframes animate-inprogress {
+  0% {
+      background-position: 0 0;
+  }
+  100% {
+      background-position: 60px 0;
+  }
 }


### PR DESCRIPTION
**Adds styling for w-buttons with all variants/states and sizes.** 

<img width="993" alt="image" src="https://github.com/user-attachments/assets/39f1c786-d61d-41c8-87ca-3da63c818765" />


**Missing logic(?)**
Some logic is needed (or maybe its just a matter of tuning props:
Variants:  Allowed values: empty, or one of variant (see storybook)
Sizes:  Allowed values: empty(default) or one size 
widths: Allowed values: empty(default) or one width 
States: Allowed values: empty(default) or any number of states

Loading state:  Pattern is supposed to be: button is triggered, button is disabled until loading success, while in the disabled state it also show loading animation to show something is happening.  Currently I styled it to disabled when the Loading prop is set , but I guess it would be cleaner to make sure the button is actually also disabled=true when the loading prop is set and that will trigger the disabled styling naturally anyways. 

**w-button--link**
Added back w-button--link, we are not removing the button variant  that looks like a link, we are removig the link that looks like a link and the link that looks like a button from this component.

**Button pill**
Removed the w-button--pill, its deprecated but the documentation should give clear advice on what the teams are supposed to use instead. This was a button type made to work on any background and was primarely used for the favorite icon top right on images.

**Mapping the props to actual classes**
Might be a trivial thing, but Id suggest we make some kind of  direct mapping props > css-classes, just to let these two worlds follow their own natural patterns.  something like:    
 /*
  primary: 'w-button--primary',
  secondary: 'w-button--secondary',
  negative: 'w-button--negative',
  utility: 'w-button--utility',
  link: 'w-button--link',
  quiet: 'w-button--quiet',
  negativeQuiet: 'w-button--negative-quiet',
  utilityQuiet: 'w-button--utility-quiet',
  small: 'w-button--small',
  fullWidth: 'w-button--full-width',
  loading: 'w-button--loading',
*/ 