### PR TITLE
warp-880 Add hasIconOnly prop

### DIFF
--- a/react/button/Button.stories.tsx
+++ b/react/button/Button.stories.tsx
@@ -11,10 +11,12 @@ export default {
         'secondary',
         'negative',
         'utility',
-        'quiet',
         'negativeQuiet',
         'utilityQuiet',
+        'overlay',
         'overlayQuiet',
+        'overlayInverted',
+        'overlayInvertedQuiet',
         'link',
       ],
     },
@@ -47,7 +49,13 @@ export const Example = () => (
 
       <Button variant="utility">Utility</Button>
 
-      <Button variant="quiet">Quiet</Button>
+      <Button variant="overlay">Overlay</Button>
+
+      <Button variant="overlayInverted">Overlay-Inverted</Button>
+
+      <Button variant="overlayQuiet">Overlay</Button>
+
+      <Button variant="overlayInvertedQuiet">Overlay-Inverted</Button>
 
       <Button variant="negativeQuiet">Negative-Quiet</Button>
 
@@ -181,9 +189,32 @@ export const Example = () => (
 
     <div>
       <h3>Overlay</h3>
-      <Button variant="overlayQuiet">Overlay quiet</Button>
+      <Button variant="overlay">Overlay</Button>
     </div>
-
+    <div>
+      <h3>Overlay Quiet</h3>
+      <Button variant="overlayQuiet">Overlay Quiet</Button>
+    </div>
+    <div>
+      <h3>Overlay Inverted</h3>
+      <Button variant="overlayInverted">Overlay Inverted</Button>
+    </div>
+    <div>
+      <h3>Overlay Inverted Quiet</h3>
+      <Button variant="overlayInvertedQuiet">Overlay Inverted Quiet</Button>
+    </div>
+    <div>
+      <h3>Overlay with Icon</h3>
+      <Button variant="overlayInvertedQuiet" hasIconOnly>
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16" class="s-icon"><title>Three dots</title><circle cx="2.4" cy="8" r="1.4" fill="currentColor"></circle><circle cx="8" cy="8" r="1.4" fill="currentColor"></circle><circle cx="13.6" cy="8" r="1.4" fill="currentColor"></circle></svg>
+      </Button>
+    </div>
+    <div>
+      <h3>Overlay with Icon</h3>
+      <Button variant="overlayInvertedQuiet" hasIconOnly>
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16" class="s-icon"><title>Three dots</title><circle cx="2.4" cy="8" r="1.4" fill="currentColor"></circle><circle cx="8" cy="8" r="1.4" fill="currentColor"></circle><circle cx="13.6" cy="8" r="1.4" fill="currentColor"></circle></svg>
+      </Button>
+    </div>
     <div>
       <h3>Full width button</h3>
 

--- a/react/button/Button.stories.tsx
+++ b/react/button/Button.stories.tsx
@@ -49,20 +49,13 @@ export const Example = () => (
 
       <Button variant="utility">Utility</Button>
 
-      <Button variant="overlay">Overlay</Button>
-
-      <Button variant="overlayInverted">Overlay-Inverted</Button>
-
-      <Button variant="overlayQuiet">Overlay</Button>
-
-      <Button variant="overlayInvertedQuiet">Overlay-Inverted</Button>
-
       <Button variant="negativeQuiet">Negative-Quiet</Button>
 
       <Button variant="utilityQuiet">utility-Quiet</Button>
 
       <p style={{ marginTop: '10px' }}>
-        This is a <Button variant="link">button</Button> pretending to be a link.
+        This is a <Button variant="link">button</Button> pretending to
+        be a link.
       </p>
     </div>
 
@@ -86,8 +79,10 @@ export const Example = () => (
       <h3>States</h3>
       <p>Allowed values: empty(default) or any number of states</p>
       <p>
-        Loading state, Pattern is supposed to be: button is triggered, button is disabled until loading success, while
-        in the disabled state it also show loading animation to show something is happening.
+        Loading state, Pattern is supposed to be: button is triggered,
+        button is disabled until loading success, while in the
+        disabled state it also show loading animation to show
+        something is happening.
       </p>
       <Button>Default</Button>
 
@@ -184,35 +179,61 @@ export const Example = () => (
 
     <div>
       <h3>Link</h3>
-      This is a <Button variant="link">button</Button> pretending to be a link.
-    </div>
-
-    <div>
-      <h3>Overlay</h3>
-      <Button variant="overlay">Overlay</Button>
+      This is a <Button variant="link">button</Button> pretending to
+      be a link.
     </div>
     <div>
-      <h3>Overlay Quiet</h3>
-      <Button variant="overlayQuiet">Overlay Quiet</Button>
-    </div>
-    <div>
-      <h3>Overlay Inverted</h3>
-      <Button variant="overlayInverted">Overlay Inverted</Button>
-    </div>
-    <div>
-      <h3>Overlay Inverted Quiet</h3>
-      <Button variant="overlayInvertedQuiet">Overlay Inverted Quiet</Button>
-    </div>
-    <div>
-      <h3>Overlay with Icon</h3>
-      <Button variant="overlayInvertedQuiet" hasIconOnly>
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16" class="s-icon"><title>Three dots</title><circle cx="2.4" cy="8" r="1.4" fill="currentColor"></circle><circle cx="8" cy="8" r="1.4" fill="currentColor"></circle><circle cx="13.6" cy="8" r="1.4" fill="currentColor"></circle></svg>
+      <h3>Utility quiet with Icon</h3>
+      <Button variant="utilityQuiet" hasIconOnly>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          fill="none"
+          viewBox="0 0 16 16"
+        >
+          <title>Three dots</title>
+          <circle
+            cx="2.4"
+            cy="8"
+            r="1.4"
+            fill="currentColor"
+          ></circle>
+          <circle cx="8" cy="8" r="1.4" fill="currentColor"></circle>
+          <circle
+            cx="13.6"
+            cy="8"
+            r="1.4"
+            fill="currentColor"
+          ></circle>
+        </svg>
       </Button>
     </div>
     <div>
-      <h3>Overlay with Icon</h3>
-      <Button variant="overlayInvertedQuiet" hasIconOnly>
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16" class="s-icon"><title>Three dots</title><circle cx="2.4" cy="8" r="1.4" fill="currentColor"></circle><circle cx="8" cy="8" r="1.4" fill="currentColor"></circle><circle cx="13.6" cy="8" r="1.4" fill="currentColor"></circle></svg>
+      <h3>Primary with Icon</h3>
+      <Button variant="primary" hasIconOnly>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          fill="none"
+          viewBox="0 0 16 16"
+        >
+          <title>Three dots</title>
+          <circle
+            cx="2.4"
+            cy="8"
+            r="1.4"
+            fill="currentColor"
+          ></circle>
+          <circle cx="8" cy="8" r="1.4" fill="currentColor"></circle>
+          <circle
+            cx="13.6"
+            cy="8"
+            r="1.4"
+            fill="currentColor"
+          ></circle>
+        </svg>
       </Button>
     </div>
     <div>

--- a/react/button/Button.tsx
+++ b/react/button/Button.tsx
@@ -14,7 +14,7 @@ import { messages as svMessages } from './locales/sv/messages.mjs';
 activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
 
 export const Button = (props: ButtonProps) => {
-  const { variant, size, loading, fullWidth, disabled, className, ref, ...rest } = props;
+  const { variant, size, loading, fullWidth, disabled, hasIconOnly, className, ref, ...rest } = props;
 
   const classes = classNames(
     'w-button',
@@ -27,9 +27,11 @@ export const Button = (props: ButtonProps) => {
       'w-button--negative-quiet': variant === 'negativeQuiet',
       'w-button--utility-quiet': variant === 'utilityQuiet',
       'w-button--overlay-quiet': variant === 'overlayQuiet',
+      'w-button--overlay-inverted-quiet': variant === 'overlayInvertedQuiet',
       'w-button--link': variant === 'link',
       'w-button--small': size === 'small',
       'w-button--full-width': fullWidth,
+      'w-button--has-icon-only': hasIconOnly,
       'w-button--loading': loading,
       'w-button--disabled': disabled,
     },

--- a/react/button/props.ts
+++ b/react/button/props.ts
@@ -29,10 +29,13 @@ export type ButtonProps = {
     | 'secondary'
     | 'negative'
     | 'utility'
+    | 'overlay'
+    | 'overlayInverted'
     | 'quiet'
     | 'negativeQuiet'
     | 'utilityQuiet'
     | 'overlayQuiet'
+    | 'overlayInvertedQuiet'
     | 'link';
 
   size?: 'small' | 'default';
@@ -47,6 +50,12 @@ export type ButtonProps = {
    * Sets the button's width to its parent's width. Useful on mobile when button should take full width.
    */
   fullWidth?: boolean;
+
+  /**
+   * Tightens the button's facilitate a round button for icon.
+  */
+  hasIconOnly?: boolean;
+
 
   disabled?: boolean;
 

--- a/react/button/style.css
+++ b/react/button/style.css
@@ -50,6 +50,11 @@
   border-color: var(--_border-active);
 }
 
+.w-button:focus-visible {
+  outline: 2px solid var(--w-s-color-border-focus);
+  outline-offset: var(--w-outline-offset, 1px);
+}
+
 /* Variants config */
 .w-button--primary {
   --background: var(--w-s-color-background-primary);
@@ -163,7 +168,7 @@
   max-width: none;
   --_padding-x: var(--_padding-y);
   aspect-ratio: 1 / 1;
-  border-radius: 9999px;
+  xborder-radius: 9999px;
 }
 
 

--- a/react/button/style.css
+++ b/react/button/style.css
@@ -65,6 +65,13 @@
   --color: var(--w-s-color-text-inverted);
   --border-width: 0px;
 }
+.w-button--negative-quiet {
+  --background: transparent;
+  --background-hover: var(--w-s-color-background-negative-subtle-hover);
+  --background-active: var(--w-s-color-background-negative-subtle-active);
+  --color: var(--w-s-color-text-negative);
+  --border-width: 0px;
+}
 .w-button--utility {
   --background: var(--w-s-color-background);
   --background-hover: var(--w-s-color-background-hover);
@@ -73,32 +80,44 @@
   --border-radius: 4px;
   --border-width: 1px;
 }
-
-.w-button--quiet {
-  --border-width: 0px;
-}
-.w-button--negative-quiet {
-  --background: transparent;
-  --background-hover: var(--w-s-color-background-negative-subtle-hover);
-  --background-active: var(--w-s-color-background-negative-subtle-active);
-  --color: var(--w-s-color-text-negative);
-  --border-width: 0px;
-}
-
 .w-button--utility-quiet {
   --background: transparent;
   --color: var(--w-s-color-text);
   --border-width: 0px;
 }
-
-.w-button--overlay-quiet {
-  --background: transparent;
-  --background-hover: var(--w-color-button-pill-background-hover);
-  --background-active: var(--w-color-button-pill-background-active);
+.w-button--overlay {
+  --background: var(--w-color-background);
+  --background-hover: var(--w-color-background-hover);
+  --background-active: var(--w-color-background-active);
   --color: var(--w-s-color-text);
   --border-radius: 9999px;
   --border-width: 0px;
 }
+.w-button--overlay-quiet {
+  --background: transparent;
+  --background-hover: var(--w-s-color-background-hover);
+  --background-active: var(--w-s-color-background-active);
+  --color: var(--w-s-color-text);
+  --border-radius: 9999px;
+  --border-width: 0px;
+}
+.w-button--overlay-inverted {
+  --background: var(--w-s-color-background-inverted);
+  --background-hover: var(--w-s-color-background-inverted-hover);
+  --background-active: var(--w-s-color-background-inverted-active);
+  --color: var(--w-s-color-text-inverted);
+  --border-radius: 9999px;
+  --border-width: 0px;
+}
+.w-button--overlay-inverted-quiet {
+  --background: transparent;
+  --background-hover: var(--w-s-color-background-inverted-hover);
+  --background-active: var(--w-s-color-background-inverted-active);
+  --color: var(--w-s-color-text-inverted);
+  --border-radius: 9999px;
+  --border-width: 0px;
+}
+
 
 .w-button--link {
   --background: none;
@@ -138,6 +157,15 @@
   width: 100%;
   max-width: 100%;
 }
+
+.w-button--has-icon-only {
+  width: auto;
+  max-width: none;
+  --_padding-x: var(--_padding-y);
+  aspect-ratio: 1 / 1;
+  border-radius: 9999px;
+}
+
 
 /* Copy of loading animation from warp  */
 .w-button--loading {


### PR DESCRIPTION
Adds a hasIconOnly prop that deals with less internal padding needed for a perfectly round button.
Should work fine with any size.

**Adds 3 new button variants, these are experimental, lack some tokens:**
overlay
overlay-inverted
overlay-inverted quiet

**Removes variant:**
quiet (This should not be its own variant, probably based on a misunderstanding) 