### PR TITLE
fix(icon): prevent redefinition of 'w-icon' custom element

### DIFF
--- a/src/icon/index.ts
+++ b/src/icon/index.ts
@@ -105,4 +105,6 @@ declare global {
   }
 }
 
-customElements.define('w-icon', WIcon);
+if (!customElements.get('w-icon')) {
+  customElements.define('w-icon', WIcon);
+}


### PR DESCRIPTION
Adds a definition check to custom icon element, prevents this error message:

<img width="574" height="85" alt="Screenshot 2025-07-24 at 10 54 30" src="https://github.com/user-attachments/assets/d10a3685-e63c-4b8d-9f14-7bda57a2109f" />
