### PR TITLE
chore: add basic custom elements manifest setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+types/
 
 .DS_Store
 **/.DS_Store

--- a/cem/config.js
+++ b/cem/config.js
@@ -1,0 +1,35 @@
+import { jsxTypesPlugin } from "@wc-toolkit/jsx-types";
+
+export default {
+  // Globs to analyze
+  globs: ['src/**/index.ts'],
+
+  // Globs to exclude
+  exclude: [],
+  
+  // Directory to output CEM to
+  outdir: 'dist/',
+  
+  // Run in dev mode, provides extra logging
+  dev: false,
+  
+  // Run in watch mode, runs on file changes
+  watch: false,
+  
+  // Include third party custom elements manifests
+  dependencies: true,
+  
+  // Output CEM path to `package.json`, defaults to true
+  packagejson: true,
+  
+  // Enable special handling for litelement
+  litelement: true,
+
+  // Plugins to use
+  plugins: [
+    jsxTypesPlugin({
+      outdir: 'types',
+      fileName: 'jsx-integration.d.ts',
+    }),
+  ],
+}

--- a/package.json
+++ b/package.json
@@ -4,8 +4,21 @@
   "description": "Next Gen Warp Components",
   "type": "module",
   "exports": {
-    "./*": "./dist/packages/*/index.js",
-    "./react/*": "./dist/react/*/index.js"
+    ".": {
+      "types": "./types/jsx-integration.d.ts"
+    },
+    "./jsx": {
+      "types": "./types/jsx-integration.d.ts"
+    },
+    "./*": {
+      "types": "./dist/packages/*/index.d.ts",
+      "default": "./dist/packages/*/index.js"
+    },
+    "./react/*": {
+      "types": "./dist/react/*/index.d.ts",
+      "default": "./dist/react/*/index.js"
+    },
+    "./custom-elements.json": "./dist/custom-elements.json"
   },
   "typesVersions": {
     "*": {
@@ -17,14 +30,17 @@
       ]
     }
   },
+  "types": "./types/jsx-integration.d.ts",
   "files": [
-    "dist/"
+    "dist/",
+    "./types"
   ],
   "scripts": {
     "build-storybook:lit": "storybook build -c .storybook-lit -o storybook/lit",
     "build-storybook:react": "storybook build -c .storybook-react -o storybook/react",
     "build-storybook": "pnpm run build-storybook:react && pnpm run build-storybook:lit",
-    "build": "rm -rf dist && mkdir dist && node build.js",
+    "build:manifest": "cem analyze --config cem/config.js",
+    "build": "rm -rf dist && mkdir dist && node build.js && npm run build:manifest",
     "check": "pnpm biome check --write .",
     "format": "pnpm biome format --write .",
     "lint:check": "pnpm biome lint .",
@@ -80,5 +96,6 @@
     "@lingui/core": "5.x",
     "@lit/react": "^1.0.3",
     "lit": "^3.1.2"
-  }
+  },
+  "customElements": "dist/custom-elements.json"
 }


### PR DESCRIPTION
Adds CEM generation with additional types via plugin.

In theory this setup should be right but need to test the exported paths and such in package.json to be sure.